### PR TITLE
added dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    reviewers: 
+      - "DevJackSmith"
+      - "AardWolf"
+      - "tehhowch"


### PR DESCRIPTION
Added the correct ecosystem to the .github/dependabot.yml file
Now, dependabot should check for updates once a week and automatically assign the expected reviewers to the PRs it opens.