### PR TITLE
Add action to keep stale repo workflow alive

### DIFF
--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -39,3 +39,6 @@ jobs:
           push: true
           tags: tsitu/mhct-db-docker:nightly,tsitu/mhct-db-docker:latest
           labels: ${{ steps.meta.outputs.labels }}
+
+      # Action to keep workflow going before 60 days of repo inactivity
+      - uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
GitHub Action workflows will disable after 60 days of repo inactivity. The keepalive-workflow will create a dummy commit (every 50 days if needed) to keep the nightly workflow going.