### PR TITLE
Update defunct backup URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y curl
 ADD ./_preload.sh /docker-entrypoint-initdb.d/
 
 # COPY db files to /docker-entrypoint-initdb.d/
-RUN echo "[ DB Last Updated ]" && curl https://devjacksmith.keybase.pub/mh_backups/nightly/last_updated.txt?dl=1
-RUN curl https://devjacksmith.keybase.pub/mh_backups/nightly/hunthelper_nightly.sql.gz?dl=1 -o /docker-entrypoint-initdb.d/hunthelper_nightly.sql.gz
+RUN echo "[ DB Last Updated ]" && curl https://backups.mhct.win/nightly/last_updated.txt
+RUN curl https://backups.mhct.win/nightly/hunthelper_nightly.sql.gz -o /docker-entrypoint-initdb.d/hunthelper_nightly.sql.gz
 
 # Need to change the datadir to something else that /var/lib/mysql because the parent docker file defines it as a volume.
 # https://docs.docker.com/engine/reference/builder/#volume :

--- a/DockerfileConv
+++ b/DockerfileConv
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y curl
 ADD ./_preload.sh /docker-entrypoint-initdb.d/
 
 # COPY db files to /docker-entrypoint-initdb.d/
-RUN echo "[ DB Last Updated ]" && curl https://devjacksmith.keybase.pub/mh_backups/weekly/last_updated.txt?dl=1
-RUN curl https://devjacksmith.keybase.pub/mh_backups/weekly/converter_weekly.sql.gz?dl=1 -o /docker-entrypoint-initdb.d/converter_weekly.sql.gz
+RUN echo "[ DB Last Updated ]" && curl https://backups.mhct.win/weekly/last_updated.txt
+RUN curl https://backups.mhct.win/weekly/converter_weekly.sql.gz -o /docker-entrypoint-initdb.d/converter_weekly.sql.gz
 
 # Need to change the datadir to something else that /var/lib/mysql because the parent docker file defines it as a volume.
 # https://docs.docker.com/engine/reference/builder/#volume :

--- a/DockerfileMaps
+++ b/DockerfileMaps
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y curl
 ADD ./_preload.sh /docker-entrypoint-initdb.d/
 
 # COPY db files to /docker-entrypoint-initdb.d/
-RUN echo "[ DB Last Updated ]" && curl https://devjacksmith.keybase.pub/mh_backups/weekly/last_updated.txt?dl=1
-RUN curl https://devjacksmith.keybase.pub/mh_backups/weekly/mapspotter_weekly.sql.gz?dl=1 -o /docker-entrypoint-initdb.d/mapspotter_weekly.sql.gz
+RUN echo "[ DB Last Updated ]" && curl https://backups.mhct.win/weekly/last_updated.txt
+RUN curl https://backups.mhct.win/weekly/mapspotter_weekly.sql.gz -o /docker-entrypoint-initdb.d/mapspotter_weekly.sql.gz
 
 # Need to change the datadir to something else that /var/lib/mysql because the parent docker file defines it as a volume.
 # https://docs.docker.com/engine/reference/builder/#volume :

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐳 MHCT DB Docker &middot; [![Build Status](https://img.shields.io/docker/cloud/build/tsitu/mhct-db-docker.svg)](https://hub.docker.com/r/tsitu/mhct-db-docker/builds)
 
-Docker images aimed at simplifying access to MHCT's various databases. Each image contains a MySQL 8.0 (debian) server preloaded with data from MHCT's [Keybase backups](https://keybase.pub/devjacksmith/mh_backups/).
+Docker images aimed at simplifying access to MHCT's various databases. Each image contains a MySQL 8.0 (debian) server preloaded with data from [MHCT's backups](https://backups.mhct.win/).
 
 Based on [Bavo's repo](https://github.com/bavovanachte/jacks-tools-docker).
 


### PR DESCRIPTION
Since keybase.pub was shuttered, you have to use the keybase client to
access the files which is a higher barrier to entry.

It was decided to host the files from the mhct.win website. This commit
will update all keybase URLs to point to the new backups.mhct.win URLs.
